### PR TITLE
Fix: audit fixes

### DIFF
--- a/src/core/Accountant/AccountantAaveV3.sol
+++ b/src/core/Accountant/AccountantAaveV3.sol
@@ -117,6 +117,8 @@ contract AccountantAaveV3 is ReentrancyGuardUpgradeable, AccountantAaveV3Base {
         AccountantAaveV3Storage.AccountantAaveV3State storage $ = AccountantAaveV3Storage.getAccountantAaveV3Storage();
 
         uint256 oldRate = $.lastRealizedFeeExchangeRate;
+        if (lastRealizedFeeExchangeRate_ <= oldRate) return;
+
         $.lastRealizedFeeExchangeRate = lastRealizedFeeExchangeRate_;
         emit LastRealizedFeeExchangeRateUpdated(oldRate, lastRealizedFeeExchangeRate_);
     }

--- a/src/core/Superloop/SuperloopVault.sol
+++ b/src/core/Superloop/SuperloopVault.sol
@@ -49,19 +49,19 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
     }
 
     function previewDeposit(uint256 assets) public view override returns (uint256) {
-        return _convertToSharesWithPerformanceFee(assets);
+        return _convertToSharesWithPerformanceFee(assets, Math.Rounding.Floor);
     }
 
     function previewMint(uint256 shares) public view override returns (uint256) {
-        return _convertToAssetsWithPerformanceFee(shares);
+        return _convertToAssetsWithPerformanceFee(shares, Math.Rounding.Ceil);
     }
 
     function previewWithdraw(uint256 assets) public view override returns (uint256) {
-        return _convertToSharesWithPerformanceFee(assets);
+        return _convertToSharesWithPerformanceFee(assets, Math.Rounding.Ceil);
     }
 
     function previewRedeem(uint256 shares) public view override returns (uint256) {
-        return _convertToAssetsWithPerformanceFee(shares);
+        return _convertToAssetsWithPerformanceFee(shares, Math.Rounding.Floor);
     }
 
     function maxMint(address) public view override returns (uint256) {
@@ -201,7 +201,11 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
         );
     }
 
-    function _convertToSharesWithPerformanceFee(uint256 assets) internal view returns (uint256) {
+    function _convertToSharesWithPerformanceFee(uint256 assets, Math.Rounding rounding)
+        internal
+        view
+        returns (uint256)
+    {
         (uint256 exchangeRate, uint8 decimals) = _getCurrentExchangeRate();
         uint256 treasuryShares = _getPerformanceFeeAndShares(
             exchangeRate, SuperloopStorage.getSuperloopEssentialRolesStorage().accountantModule, decimals
@@ -209,12 +213,16 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
         uint256 _totalSupply = totalSupply() + treasuryShares + 10 ** _decimalsOffset();
         uint256 _totalAssets = totalAssets() + 1;
 
-        uint256 shares = Math.mulDiv(assets, _totalSupply, _totalAssets, Math.Rounding.Floor);
+        uint256 shares = Math.mulDiv(assets, _totalSupply, _totalAssets, rounding);
 
         return shares;
     }
 
-    function _convertToAssetsWithPerformanceFee(uint256 shares) internal view returns (uint256) {
+    function _convertToAssetsWithPerformanceFee(uint256 shares, Math.Rounding rounding)
+        internal
+        view
+        returns (uint256)
+    {
         (uint256 exchangeRate, uint8 decimals) = _getCurrentExchangeRate();
         uint256 treasuryShares = _getPerformanceFeeAndShares(
             exchangeRate, SuperloopStorage.getSuperloopEssentialRolesStorage().accountantModule, decimals
@@ -222,7 +230,7 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
         uint256 _totalSupply = totalSupply() + treasuryShares + 10 ** _decimalsOffset();
         uint256 _totalAssets = totalAssets() + 1;
 
-        uint256 assets = Math.mulDiv(shares, _totalAssets, _totalSupply, Math.Rounding.Ceil);
+        uint256 assets = Math.mulDiv(shares, _totalAssets, _totalSupply, rounding);
 
         return assets;
     }

--- a/src/core/Superloop/SuperloopVault.sol
+++ b/src/core/Superloop/SuperloopVault.sol
@@ -157,13 +157,14 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
 
         uint256 sharesToMint = _getPerformanceFeeAndShares(exchangeRate, $.accountantModule, decimals);
 
-        // mint the shares to the treasury
-        _mint($.treasury, sharesToMint);
-
         // update the last realized fee exchange rate on the accountant module via delegate call
         IAccountantModule($.accountantModule).setLastRealizedFeeExchangeRate(exchangeRate);
 
+        // if vault made profit, take a performance fee
         if (sharesToMint > 0) {
+            // mint the shares to the treasury
+            _mint($.treasury, sharesToMint);
+
             emit PerformanceFeeRealized(sharesToMint, $.treasury);
         }
     }

--- a/src/core/Superloop/SuperloopVault.sol
+++ b/src/core/Superloop/SuperloopVault.sol
@@ -173,12 +173,14 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
         view
         returns (uint256 shares)
     {
-        // get performance fee
-        uint256 assets = IAccountantModule(accountantModule).getPerformanceFee(totalAssets(), exchangeRate, decimals);
-
-        // calculate how much shares to dilute ie. mint for the treasury as performance fee
         uint256 totalAssetsCached = totalAssets();
         uint256 totalSupplyCached = totalSupply();
+
+        // get performance fee
+        uint256 assets =
+            IAccountantModule(accountantModule).getPerformanceFee(totalSupplyCached, exchangeRate, decimals);
+
+        // calculate how much shares to dilute ie. mint for the treasury as performance fee
         uint256 denominator = totalAssetsCached - assets;
         uint256 numerator = (totalAssetsCached * totalSupplyCached) - (totalSupplyCached * denominator);
 

--- a/src/core/Superloop/SuperloopVault.sol
+++ b/src/core/Superloop/SuperloopVault.sol
@@ -181,8 +181,9 @@ abstract contract SuperloopVault is ERC4626Upgradeable, ReentrancyGuardUpgradeab
             IAccountantModule(accountantModule).getPerformanceFee(totalSupplyCached, exchangeRate, decimals);
 
         // calculate how much shares to dilute ie. mint for the treasury as performance fee
-        uint256 denominator = totalAssetsCached - assets;
-        uint256 numerator = (totalAssetsCached * totalSupplyCached) - (totalSupplyCached * denominator);
+        uint256 denominator = totalAssetsCached - assets + 1;
+        uint256 numerator = ((totalAssetsCached + 1) * (totalSupplyCached + 10 ** _decimalsOffset()))
+            - ((totalSupplyCached + 10 ** _decimalsOffset()) * denominator);
 
         if (numerator != 0) {
             shares = numerator / denominator;

--- a/src/core/WithdrawManager/WithdrawManager.sol
+++ b/src/core/WithdrawManager/WithdrawManager.sol
@@ -201,7 +201,12 @@ contract WithdrawManager is Initializable, ReentrancyGuardUpgradeable, Context, 
         // call the redeem function on the vault
         uint256 totalAssetsRedeemed = IERC4626($.vault).redeem(totalShares, address(this), address(this));
 
-        require(totalAssetsRedeemed == totalAssetsDistributed, Errors.INVALID_ASSETS_DISTRIBUTED);
+        require(totalAssetsRedeemed >= totalAssetsDistributed, Errors.INVALID_ASSETS_DISTRIBUTED);
+
+        // if redeemed more than distributed, return the difference to the vault
+        if (totalAssetsRedeemed > totalAssetsDistributed) {
+            SafeERC20.safeTransfer(IERC20($.asset), _msgSender(), totalAssetsRedeemed - totalAssetsDistributed);
+        }
 
         WithdrawManagerStorage.setResolvedWithdrawRequestId(resolvedIdLimit);
     }

--- a/test/core/TestBase.sol
+++ b/test/core/TestBase.sol
@@ -39,6 +39,8 @@ contract TestBase is Test {
     address public constant WBTC = 0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F;
     address public constant ROUTER = 0xbfe9C246A5EdB4F021C8910155EC93e7CfDaB7a0;
     address public constant USDC_WHALE = 0xd03bfdF9B26DB1e6764724d914d7c3d18106a9Fb;
+    address public constant POOL_CONFIGURATOR = 0x30F6880Bb1cF780a49eB4Ef64E64585780AAe060;
+    address public constant POOL_ADMIN = 0x669bd328f6C494949Ed9fB2dc8021557A6Dd005f;
 
     address public admin;
     address public treasury;

--- a/test/core/integration/IntegrationBase.sol
+++ b/test/core/integration/IntegrationBase.sol
@@ -17,9 +17,6 @@ abstract contract IntegrationBase is TestBase {
     Superloop public superloopImplementation;
     ProxyAdmin public proxyAdmin;
 
-    address public constant POOL_CONFIGURATOR = 0x30F6880Bb1cF780a49eB4Ef64E64585780AAe060;
-    address public constant POOL_ADMIN = 0x669bd328f6C494949Ed9fB2dc8021557A6Dd005f;
-
     address public user1;
     address public user2;
     address public user3;
@@ -101,6 +98,7 @@ abstract contract IntegrationBase is TestBase {
 
         vm.startPrank(POOL_ADMIN);
         IPoolConfigurator(POOL_CONFIGURATOR).setReserveFlashLoaning(ST_XTZ, true);
+        IPoolConfigurator(POOL_CONFIGURATOR).setSupplyCap(ST_XTZ, 10000000);
         vm.stopPrank();
     }
 

--- a/test/modules/AaveV3BorrowModule.t.sol
+++ b/test/modules/AaveV3BorrowModule.t.sol
@@ -10,6 +10,7 @@ import {ProxyAdmin} from "openzeppelin-contracts/contracts/proxy/transparent/Pro
 import {TransparentUpgradeableProxy} from
     "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IPoolConfigurator} from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
 import {console} from "forge-std/console.sol";
 
 contract AaveV3BorrowModuleTest is TestBase {
@@ -54,6 +55,11 @@ contract AaveV3BorrowModuleTest is TestBase {
         user = makeAddr("user");
         vm.label(user, "user");
         vm.label(address(superloop), "superloop");
+
+        vm.startPrank(POOL_ADMIN);
+        IPoolConfigurator(POOL_CONFIGURATOR).setReserveFlashLoaning(ST_XTZ, true);
+        IPoolConfigurator(POOL_CONFIGURATOR).setSupplyCap(ST_XTZ, 10000000);
+        vm.stopPrank();
     }
 
     function test_BorrowBasicFlow() public {

--- a/test/modules/AaveV3RepayModule.t.sol
+++ b/test/modules/AaveV3RepayModule.t.sol
@@ -10,6 +10,7 @@ import {ProxyAdmin} from "openzeppelin-contracts/contracts/proxy/transparent/Pro
 import {TransparentUpgradeableProxy} from
     "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IPoolConfigurator} from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
 import {console} from "forge-std/console.sol";
 
 contract AaveV3RepayModuleTest is TestBase {
@@ -55,6 +56,11 @@ contract AaveV3RepayModuleTest is TestBase {
         user = makeAddr("user");
         vm.label(user, "user");
         vm.label(address(superloop), "superloop");
+
+        vm.startPrank(POOL_ADMIN);
+        IPoolConfigurator(POOL_CONFIGURATOR).setReserveFlashLoaning(ST_XTZ, true);
+        IPoolConfigurator(POOL_CONFIGURATOR).setSupplyCap(ST_XTZ, 10000000);
+        vm.stopPrank();
     }
 
     function test_RepayBasicFlow() public {


### PR DESCRIPTION
## Audit fixes
1. [Incorrect input causes wrong performance fee #36](https://github.com/sherlock-audit/2025-07-superlend-july-25th/issues/36)
2. [Performance fee shares are computed incorrectly and treasury is at a loss #44](https://github.com/sherlock-audit/2025-07-superlend-july-25th/issues/44)
3. [Wrong rounding directions when withdrawing and redeeming #37](https://github.com/sherlock-audit/2025-07-superlend-july-25th/issues/37)
4. [Fees are taken even when the vaults are at a loss #45](https://github.com/sherlock-audit/2025-07-superlend-july-25th/issues/45)
5. [Invariant will often fail due to cumulative rounding #38](https://github.com/sherlock-audit/2025-07-superlend-july-25th/issues/38)